### PR TITLE
[Epic: The Docs Strike First] Episode 1.1 — Compile to Survive: note build requirement [v0.1.0]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ TESTS (unit/integration names, locations, expected outputs/logs)
 CLI/USAGE (commands and expected exit codes) — if relevant
 
 ACCEPTANCE (what must be green)
+C++ code must compile successfully.
 
 CHANGELOG (prepend exact TITLE line)
 
@@ -279,6 +280,7 @@ CLI/USAGE (if relevant)
 
 ACCEPTANCE
 - What must be green (build/tests/CI).
+- C++ code must compile successfully.
 
 CHANGELOG (prepend this exact line)
 <repeat the TITLE line>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+[Epic: The Docs Strike First] Episode 1.1 — Compile to Survive: note build requirement [v0.1.0]
 [Epic: The Docs Strike First] Episode 1.0 — Press F to Fabricate: Python bootstraps plugin skeleton [v0.1.0]
 [Epic: The Docs Strike First] Episode 0.2a — AGENTS.md, Machine-Grade (Spaces Edition): normalize spec for code agents [v0.1.0]


### PR DESCRIPTION
## Summary
- note C++ compilation requirement under acceptance guidelines
- record episode in changelog

## Testing
- `python -m py_compile Scripts/python/seqso_bootstrap_plugin.py`

## Manual Human Verification
- Confirm AGENTS.md lists “C++ code must compile successfully.” under ACCEPTANCE
- Confirm CHANGELOG.md begins with Episode 1.1 entry

------
https://chatgpt.com/codex/tasks/task_e_689c40c3b5e08323a791b7e4f26e9a1e